### PR TITLE
Comment out default env vars in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,10 @@ services:
     entrypoint: [ "/bin/bash", "/scripts/start.sh" ]
     # Environment variables
     environment:
-      Port: "25565"
-      BedrockPort: "19132"
+      #Port: "25565" # Uncomment to use port other than default Java port 25565
+      #BedrockPort: "19132" # Uncomment to use port other than default Bedrock port 19132
       TZ: "America/Denver" # Timezone
-      BackupCount: 10 # Number of rolling backups to keep
+      #BackupCount: 10 # Number of rolling backups to keep. Uncomment to change default of 10.
       #MaxMemory: 2048 # Maximum memory usage for Java
       #Version: 1.19.2 # Use custom version
       #NoBackup: "plugins" # Optional folder to skip during backups


### PR DESCRIPTION
Since I see the "Port", "BedrockPort", and "BackupCount" variables are already set to their default values, I commented these out since they are redundant. I left a brief note for users on this, like you did for the other commented-out values.

One value I was unable to verify was set to a default (likely it is not) is the TZ variable because I was unable to find where it was actually being used in the entire codebase. Could you explain to me how/where it is used and what would be its default value if left unset?

I see you have it set to America/Denver in each Dockerfile, so if commented out in docker-compose it would take this value, I understand. But what would happen if you didn't set it in the Dockerfiles either?

Signed-off-by: William Trelawny <22324745+willman42@users.noreply.github.com>