### PR TITLE
Added bind mount for easier access to config files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - 19132:19132/udp
     volumes:
       - minecraft:/minecraft
+      - ./config:/minecraft
     stdin_open: true # docker run -i
     tty: true # docker run -t
     entrypoint: [ "/bin/bash", "/scripts/start.sh" ]


### PR DESCRIPTION
Currently, the only way to access server config files is by navigating into the docker volume on the host, which is only possible as the root user.

Even if you bind mount the docker volume location to a directory accessible by a non-privileged user, you still cannot access it.

The only way to allow non-root users (still have to be part of the "docker" group in order to even run docker daemon) like server admins to access these important config files is to create a bind mount to the container's /minecraft folder upon 'docker exec' or in docker-compose.yml.

I've called the local folder "config" but you can call it whatever you want to fit the style of your project of course. This terminology is just what I've most often seen in other Docker projects for this kind of functionality.

I originally considered only making bind mounts to each individual config file in order to restrict the number of exposed files in the container, but decided on mounting the entire folder based on the Principle of Least Change. Change this as you see fit of course, but the principle remains the same- allowing server admins easier access to config files for making changes.

Many other Docker projects (Pi-hole, Wekan, Graylog, etc.) use this same methodology for giving admins access to specific required files within containers, so this is definitely what you'd call an "industry-standard" approach vs. navigating Docker volumes themselves.

Lastly, as I'm sure you'd be aware, this would require a change to the Readme to make users aware of this option and to instruct them to create the "config" folder adjacent to their docker-compose.yml files in order to utilize this functionality. Same for the "docker run" folks as well.

Signed-off-by: William Trelawny <22324745+willman42@users.noreply.github.com>