### PR TITLE
Fix Kubernetes usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ The <a href="https://github.com/TheRemote/Legendary-Bedrock-Container" target="_
   <li>Automatic backups to minecraft/backups when server restarts</li>
   <li>Updates automatically to the latest version when server is started</li>
   <li>Runs on all Docker platforms including Raspberry Pi</li>
+  <li>Runs on all Kubernetes platforms including Raspberry Pi</li>
 </ul>
 
-<h2>Usage</h2>
+<h2>Docker Usage</h2>
 First you must create a named Docker volume.  This can be done with:<br>
 <pre>docker volume create yourvolumename</pre>
 
@@ -47,6 +48,25 @@ Skipping backups on certain folders (comma separated):
 <pre>docker run -it -v yourvolumename:/minecraft -p 25565:25565 -p 19132:19132/udp -p 19132:19132 -e NoBackup="plugins/ftp,plugins/test2" --restart unless-stopped 05jchambers/legendary-minecraft-geyser-floodgate:latest</pre>
 Skipping permissions check:
 <pre>docker run -it -v yourvolumename:/minecraft -p 25565:25565 -p 19132:19132/udp -p 19132:19132 -e NoPermCheck="Y" --restart unless-stopped 05jchambers/legendary-minecraft-geyser-floodgate:latest</pre>
+
+<h2>Kubernetes Usage</h2>
+First you must create a suitable PVC using your preferred StorageClass.<br>
+To run within Kubernetes, you must pass the enviroment variable `k8s="True"`
+alongside any others you require:<br>
+<pre>
+        env:
+        - name: MaxMemory
+          value: '1024'
+        - name: TZ
+          value: Europe/London
+        - name: k8s
+          value: "True"
+</pre>
+<bold>Be aware that terminal features will not be available when running in kubernetes</bold>
+<br>
+The pod can be exposed using a LoadBalancer or TCP/UDP Ingress service.  See example manifests in the /kubernetes folder of the repo.  The examples are based on Longhorn
+storage backend and a LoadBalancer service - these will need altering to be suitable
+for your environment.<br>
 
 <h2>Configuration / Accessing Server Files</h2>
 The server data is stored where Docker stores your volumes.  This is typically a folder on the host OS that is shared and mounted with the container.<br>

--- a/kubernetes/01-namespace.yaml
+++ b/kubernetes/01-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minecraft
+  labels:
+    name: minecraft

--- a/kubernetes/02-pvc.yaml
+++ b/kubernetes/02-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minecraft-pvc
+  namespace: minecraft
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-retain
+  resources:
+    requests:
+      storage: 3Gi

--- a/kubernetes/03-deployment.yaml
+++ b/kubernetes/03-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: minecraft
+  name: minecraft
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minecraft
+  template:
+    metadata:
+      labels:
+        app: minecraft
+    spec:
+      containers:
+      - name: minecraft
+        image: 05jchambers/legendary-minecraft-geyser-floodgate:latest
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: minecraft-data
+          mountPath: /minecraft
+        env:
+        - name: MaxMemory
+          value: '1024'
+        - name: k8s
+          value: "True"
+        resources:
+          limits:
+            cpu: 1500m
+            memory: 1024M
+            ephemeral-storage: 50Mi
+          requests:
+            cpu: 750m
+            memory: 750M
+            ephemeral-storage: 2Mi
+        ports:
+        - containerPort: 25565
+          name: java
+        - containerPort: 19132
+          name: bedrock-v4
+        - containerPort: 19133
+          name: bedrock-v6
+      volumes:
+      - name: minecraft-data
+        persistentVolumeClaim:
+          claimName: minecraft-pvc

--- a/kubernetes/04-service.yaml
+++ b/kubernetes/04-service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft
+  namespace: minecraft
+spec:
+  type: LoadBalancer
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+  ports:
+    - name: java
+      port: 25565
+      protocol: TCP
+      targetPort: java
+    - name: bedrock-v4-udp
+      port: 19132
+      protocol: UDP
+      targetPort: bedrock-v4
+    - name: bedrock-v6-udp
+      port: 19133
+      protocol: UDP
+      targetPort: bedrock-v6
+    - name: bedrock-v4-tcp
+      port: 19132
+      protocol: TCP
+      targetPort: bedrock-v4
+    - name: bedrock-v6-tcp
+      port: 19133
+      protocol: TCP
+      targetPort: bedrock-v6
+  selector:
+    app: minecraft

--- a/start.sh
+++ b/start.sh
@@ -13,11 +13,13 @@ if [ ! -d '/minecraft' ]; then
     exit 1
 fi
 
-Terminal=$(readlink /proc/self/fd/0)
-if [ -z "$Terminal" ] || [ "$Terminal" != "/dev/pts/0" ]; then
-    echo "An interactive terminal is required (you don't have to attach).  Please run with docker -it or docker -itd (detached interactive terminal)."
-    sleep 10
-    exit 1
+if [ -z "$k8s" ]; then
+    Terminal=$(readlink /proc/self/fd/0)
+    if [ -z "$Terminal" ] || [ "$Terminal" != "/dev/pts/0" ]; then
+        echo "An interactive terminal is required (you don't have to attach).  Please run with docker -it or docker -itd (detached interactive terminal)."
+        sleep 10
+        exit 1
+    fi
 fi
 
 # Randomizer for user agent


### PR DESCRIPTION
When trying to run the container with Kubernetes it fails because of the interactive shell check.

I have tried the NoScreen variable mentioned in an issue but that still caused a crash but with no logs to check.

While you can open an interactive shell with Kubernetes, by default no shell is started with a pod which causes the failure.

The changes in this pull request check for a new enviromnent variable in the start.sh script:
```
if [ -z "$k8s" ]; then
    Terminal=$(readlink /proc/self/fd/0)
    if [ -z "$Terminal" ] || [ "$Terminal" != "/dev/pts/0" ]; then
        echo "An interactive terminal is required (you don't have to attach).  Please run with docker -it or docker -itd (detached interactive terminal)."
        sleep 10
        exit 1
    fi
fi
```
The changes also include:
* A brief section in the readme to explain the usage of the `k8s` variable.
* A folder with example manifests which launch a default server on the cluster.

While the terminal features of the Minecraft server will not be available, the server will correctly run and allow collections.

The test container available publicly at git.fjla.uk/fred.boniface/amd64-mc:2 has been tested on an RKE2 cluster but uses only standard Kubernetes features so will be compatible with any Kubernetes distribution.  The default mode is to continue the check to maintain compatibility for Docker users looking to use the terminal features.

There have been no changes to the Dockerfiles so cross-architecture compatibility remains unchanged and would also be compatible with cross-architecture Kubernetes users.