### PR TITLE
Adding vim to the image so that nano is not the only editor available

### DIFF
--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-s
 FROM --platform=linux/amd64 ubuntu:rolling
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm64/v8 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm/v7 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/ppc64le.Dockerfile
+++ b/ppc64le.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/ppc64le ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-ppc64le-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/riscv64 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-riscv64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/s390x ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-s390x-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565


### PR DESCRIPTION
Adding `vim` to the image would make working inside the containers more comfortable for many people.  I am not used to `nano`, so I find myself choosing to `apt update` then `apt install vim` any time I need to work on any files inside my containers based on this image.  I can't imagine that I am the only one that would prefer to use `vim` over `nano`, so this will make the image more inclusive.