### PR TITLE
!!! Reworking the Paper download to work with their new API endpoint

### DIFF
--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-s
 FROM --platform=linux/amd64 ubuntu:rolling
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm64/v8 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm/v7 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/ppc64le.Dockerfile
+++ b/ppc64le.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/ppc64le ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-ppc64le-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/riscv64 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-riscv64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/s390x ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-s390x-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565


### PR DESCRIPTION
Fixes #40 

Reworking the Paper server download to work with their new API endpoint.  This includes cleaning up the version extraction from the JSON response by using `jq`.

Adding `jq` to the Dockerfiles to support this.

Also adding `vim` to the Dockerfiles so that users have a choice between `nano` and `vim`.

Tested locally with a version with a stable build:
```
❯ ./test.sh 1.21.3
Testing version: 1.21.3
Latest paperclip build found: 82 (stable)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 48.5M  100 48.5M    0     0  28.5M      0  0:00:01  0:00:01 --:--:-- 28.4M
paperclip.jar
```
and a version with only an experimental build:
```
❯ ./test.sh 1.21.4
Testing version: 1.21.4
Unable to retrieve latest Paper build (got result of 0).  Retrying the experimental channel for version 1.21.4
Latest paperclip build found: 70 (experimental)
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 48.9M  100 48.9M    0     0  36.5M      0  0:00:01  0:00:01 --:--:-- 36.5M
paperclip.jar
```

