### PR TITLE
Overhaul of start.sh and Dockerfiles

### DIFF
--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -6,7 +6,28 @@
 FROM --platform=linux/amd64 ubuntu:rolling
 
 # Fetch dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+      apt-utils \
+      binfmt-support \
+      ca-certificates \
+      curl \
+      gawk \
+      findutils \
+      jq \
+      libcurl4 \
+      libcurl4-openssl-dev \
+      libc6 \
+      libcrypt1 \
+      net-tools \
+      nano \
+      openjdk-21-jre-headless \
+      openssl \
+      pigz \
+      tzdata \
+      unzip \
+      vim && \
+    rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -15,7 +36,7 @@ ENV Port=25565
 ENV BedrockPort=19132
 
 # Optional maximum memory Minecraft is allowed to use
-ENV MaxMemory=
+ENV MaxMemory=""
 
 # Optional Paper Minecraft Version override
 ENV Version="1.21.3"

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -2,17 +2,11 @@
 # Author: James A. Chambers - https://jamesachambers.com/minecraft-java-bedrock-server-together-geyser-floodgate/
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
-# Use Ubuntu rolling version for builder
-FROM ubuntu:rolling AS builder
-
-# Update apt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-static binfmt-support apt-utils -yqq && rm -rf /var/cache/apt/*
-
 # Use Ubuntu rolling version
 FROM --platform=linux/amd64 ubuntu:rolling
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -49,12 +43,21 @@ EXPOSE 25565/tcp
 EXPOSE 19132/tcp
 EXPOSE 19132/udp
 
-# Copy scripts to minecraftbe folder and make them executable
+# Copy files into image and make the scripts executable
 RUN mkdir /scripts
 COPY *.sh /scripts/
 COPY *.yml /scripts/
 COPY server.properties /scripts/
 RUN chmod -R +x /scripts/*.sh
+
+# Create the minecraft user/group and set the container to run as the minecraft user
+RUN groupadd -g 999 minecraft && \
+    useradd -m -u 999 -g 999 -s /bin/bash minecraft && \
+    mkdir /minecraft && \
+    chown minecraft:minecraft /minecraft && \
+    chmod 777 /minecraft
+USER minecraft
+WORKDIR /minecraft
 
 # Set entrypoint to start.sh script
 ENTRYPOINT ["/bin/bash", "/scripts/start.sh"]

--- a/amd64.Dockerfile
+++ b/amd64.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-s
 FROM --platform=linux/amd64 ubuntu:rolling
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -3,10 +3,12 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM ubuntu:rolling AS builder
+FROM --platform=linux/arm64/v8 ubuntu:rolling AS builder
 
-# Update apt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-static binfmt-support apt-utils -yqq && rm -rf /var/cache/apt/*
+# Prep qemu files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq apt-utils binfmt-support qemu-user-static && \
+    rm -rf /var/cache/apt/*
 
 # Use Ubuntu rolling version
 FROM --platform=linux/arm64/v8 ubuntu:rolling
@@ -15,7 +17,28 @@ FROM --platform=linux/arm64/v8 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+      apt-utils \
+      binfmt-support \
+      ca-certificates \
+      curl \
+      gawk \
+      findutils \
+      jq \
+      libcurl4 \
+      libcurl4-openssl-dev \
+      libc6 \
+      libcrypt1 \
+      net-tools \
+      nano \
+      openjdk-21-jre-headless \
+      openssl \
+      pigz \
+      tzdata \
+      unzip \
+      vim && \
+    rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -24,7 +47,7 @@ ENV Port=25565
 ENV BedrockPort=19132
 
 # Optional maximum memory Minecraft is allowed to use
-ENV MaxMemory=
+ENV MaxMemory=""
 
 # Optional Paper Minecraft Version override
 ENV Version="1.21.3"
@@ -52,12 +75,21 @@ EXPOSE 25565/tcp
 EXPOSE 19132/tcp
 EXPOSE 19132/udp
 
-# Copy scripts to minecraftbe folder and make them executable
+# Copy files into image and make the scripts executable
 RUN mkdir /scripts
 COPY *.sh /scripts/
 COPY *.yml /scripts/
 COPY server.properties /scripts/
 RUN chmod -R +x /scripts/*.sh
+
+# Create the minecraft user/group and set the container to run as the minecraft user
+RUN groupadd -g 999 minecraft && \
+    useradd -m -u 999 -g 999 -s /bin/bash minecraft && \
+    mkdir /minecraft && \
+    chown minecraft:minecraft /minecraft && \
+    chmod 777 /minecraft
+USER minecraft
+WORKDIR /minecraft
 
 # Set entrypoint to start.sh script
 ENTRYPOINT ["/bin/bash", "/scripts/start.sh"]

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm64/v8 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm64/v8 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-aarch64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/arm64v8.Dockerfile
+++ b/arm64v8.Dockerfile
@@ -3,7 +3,7 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM --platform=linux/arm64/v8 ubuntu:rolling AS builder
+FROM ubuntu:rolling AS builder
 
 # Prep qemu files
 RUN apt-get update && \

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm/v7 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/arm/v7 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -3,10 +3,12 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM ubuntu:rolling AS builder
+FROM --platform=linux/arm/v7 ubuntu:rolling AS builder
 
-# Update apt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-static binfmt-support apt-utils -yqq && rm -rf /var/cache/apt/*
+# Prep qemu files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq apt-utils binfmt-support qemu-user-static && \
+    rm -rf /var/cache/apt/*
 
 # Use Ubuntu rolling version
 FROM --platform=linux/arm/v7 ubuntu:rolling
@@ -15,7 +17,28 @@ FROM --platform=linux/arm/v7 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-arm-static /usr/bin/
 
 # Fetch dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4t64 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+      apt-utils \
+      binfmt-support \
+      ca-certificates \
+      curl \
+      gawk \
+      findutils \
+      jq \
+      libcurl4 \
+      libcurl4-openssl-dev \
+      libc6 \
+      libcrypt1 \
+      net-tools \
+      nano \
+      openjdk-21-jre-headless \
+      openssl \
+      pigz \
+      tzdata \
+      unzip \
+      vim && \
+    rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -24,7 +47,7 @@ ENV Port=25565
 ENV BedrockPort=19132
 
 # Optional maximum memory Minecraft is allowed to use
-ENV MaxMemory=
+ENV MaxMemory=""
 
 # Optional Paper Minecraft Version override
 ENV Version="1.21.3"
@@ -52,12 +75,21 @@ EXPOSE 25565/tcp
 EXPOSE 19132/tcp
 EXPOSE 19132/udp
 
-# Copy scripts to minecraftbe folder and make them executable
+# Copy files into image and make the scripts executable
 RUN mkdir /scripts
 COPY *.sh /scripts/
 COPY *.yml /scripts/
 COPY server.properties /scripts/
 RUN chmod -R +x /scripts/*.sh
+
+# Create the minecraft user/group and set the container to run as the minecraft user
+RUN groupadd -g 999 minecraft && \
+    useradd -m -u 999 -g 999 -s /bin/bash minecraft && \
+    mkdir /minecraft && \
+    chown minecraft:minecraft /minecraft && \
+    chmod 777 /minecraft
+USER minecraft
+WORKDIR /minecraft
 
 # Set entrypoint to start.sh script
 ENTRYPOINT ["/bin/bash", "/scripts/start.sh"]

--- a/armv7.Dockerfile
+++ b/armv7.Dockerfile
@@ -3,7 +3,7 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM --platform=linux/arm/v7 ubuntu:rolling AS builder
+FROM ubuntu:rolling AS builder
 
 # Prep qemu files
 RUN apt-get update && \

--- a/ppc64le.Dockerfile
+++ b/ppc64le.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/ppc64le ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-ppc64le-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/ppc64le.Dockerfile
+++ b/ppc64le.Dockerfile
@@ -3,7 +3,7 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM --platform=linux/ppc64le ubuntu:rolling AS builder
+FROM ubuntu:rolling AS builder
 
 # Prep qemu files
 RUN apt-get update && \

--- a/ppc64le.Dockerfile
+++ b/ppc64le.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/ppc64le ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-ppc64le-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -2,20 +2,43 @@
 # Author: James A. Chambers - https://jamesachambers.com/minecraft-java-bedrock-server-together-geyser-floodgate/
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
-# Use latest Ubuntu version for builder
-FROM ubuntu:rolling AS builder
+# Use Ubuntu rolling version for builder
+FROM --platform=linux/riscv64 ubuntu:rolling AS builder
 
-# Update apt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-static binfmt-support apt-utils -yqq && rm -rf /var/cache/apt/*
+# Prep qemu files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq apt-utils binfmt-support qemu-user-static && \
+    rm -rf /var/cache/apt/*
 
-# Use current Ubuntu LTS version
+# Use Ubuntu rolling version
 FROM --platform=linux/riscv64 ubuntu:rolling
 
 # Add QEMU
 COPY --from=builder /usr/bin/qemu-riscv64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+      apt-utils \
+      binfmt-support \
+      ca-certificates \
+      curl \
+      gawk \
+      findutils \
+      jq \
+      libcurl4 \
+      libcurl4-openssl-dev \
+      libc6 \
+      libcrypt1 \
+      net-tools \
+      nano \
+      openjdk-21-jre-headless \
+      openssl \
+      pigz \
+      tzdata \
+      unzip \
+      vim && \
+    rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -24,7 +47,7 @@ ENV Port=25565
 ENV BedrockPort=19132
 
 # Optional maximum memory Minecraft is allowed to use
-ENV MaxMemory=
+ENV MaxMemory=""
 
 # Optional Paper Minecraft Version override
 ENV Version="1.21.3"
@@ -52,12 +75,21 @@ EXPOSE 25565/tcp
 EXPOSE 19132/tcp
 EXPOSE 19132/udp
 
-# Copy scripts to minecraftbe folder and make them executable
+# Copy files into image and make the scripts executable
 RUN mkdir /scripts
 COPY *.sh /scripts/
 COPY *.yml /scripts/
 COPY server.properties /scripts/
 RUN chmod -R +x /scripts/*.sh
+
+# Create the minecraft user/group and set the container to run as the minecraft user
+RUN groupadd -g 999 minecraft && \
+    useradd -m -u 999 -g 999 -s /bin/bash minecraft && \
+    mkdir /minecraft && \
+    chown minecraft:minecraft /minecraft && \
+    chmod 777 /minecraft
+USER minecraft
+WORKDIR /minecraft
 
 # Set entrypoint to start.sh script
 ENTRYPOINT ["/bin/bash", "/scripts/start.sh"]

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/riscv64 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-riscv64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/riscv64 ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-riscv64-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/riscv64.Dockerfile
+++ b/riscv64.Dockerfile
@@ -3,7 +3,7 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM --platform=linux/riscv64 ubuntu:rolling AS builder
+FROM ubuntu:rolling AS builder
 
 # Prep qemu files
 RUN apt-get update && \

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -3,10 +3,12 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM ubuntu:rolling AS builder
+FROM --platform=linux/s390x ubuntu:rolling AS builder
 
-# Update apt
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install qemu-user-static binfmt-support apt-utils -yqq && rm -rf /var/cache/apt/*
+# Prep qemu files
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq apt-utils binfmt-support qemu-user-static && \
+    rm -rf /var/cache/apt/*
 
 # Use Ubuntu rolling version
 FROM --platform=linux/s390x ubuntu:rolling
@@ -15,7 +17,28 @@ FROM --platform=linux/s390x ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-s390x-static /usr/bin/
 
 # Fetch dependencies
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
+      apt-utils \
+      binfmt-support \
+      ca-certificates \
+      curl \
+      gawk \
+      findutils \
+      jq \
+      libcurl4 \
+      libcurl4-openssl-dev \
+      libc6 \
+      libcrypt1 \
+      net-tools \
+      nano \
+      openjdk-21-jre-headless \
+      openssl \
+      pigz \
+      tzdata \
+      unzip \
+      vim && \
+    rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565
@@ -24,7 +47,7 @@ ENV Port=25565
 ENV BedrockPort=19132
 
 # Optional maximum memory Minecraft is allowed to use
-ENV MaxMemory=
+ENV MaxMemory=""
 
 # Optional Paper Minecraft Version override
 ENV Version="1.21.3"
@@ -52,12 +75,21 @@ EXPOSE 25565/tcp
 EXPOSE 19132/tcp
 EXPOSE 19132/udp
 
-# Copy scripts to minecraftbe folder and make them executable
+# Copy files into image and make the scripts executable
 RUN mkdir /scripts
 COPY *.sh /scripts/
 COPY *.yml /scripts/
 COPY server.properties /scripts/
 RUN chmod -R +x /scripts/*.sh
+
+# Create the minecraft user/group and set the container to run as the minecraft user
+RUN groupadd -g 999 minecraft && \
+    useradd -m -u 999 -g 999 -s /bin/bash minecraft && \
+    mkdir /minecraft && \
+    chown minecraft:minecraft /minecraft && \
+    chmod 777 /minecraft
+USER minecraft
+WORKDIR /minecraft
 
 # Set entrypoint to start.sh script
 ENTRYPOINT ["/bin/bash", "/scripts/start.sh"]

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/s390x ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-s390x-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano -yqq && rm -rf /var/cache/apt/*
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -3,7 +3,7 @@
 # GitHub Repository: https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate
 
 # Use Ubuntu rolling version for builder
-FROM --platform=linux/s390x ubuntu:rolling AS builder
+FROM ubuntu:rolling AS builder
 
 # Prep qemu files
 RUN apt-get update && \

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -15,7 +15,7 @@ FROM --platform=linux/s390x ubuntu:rolling
 COPY --from=builder /usr/bin/qemu-s390x-static /usr/bin/
 
 # Fetch dependencies
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install openjdk-21-jre-headless tzdata sudo curl unzip net-tools gawk openssl findutils pigz libcurl4 libc6 libcrypt1 apt-utils libcurl4-openssl-dev ca-certificates binfmt-support nano jq vim -yqq && rm -rf /var/cache/apt/*
 
 # Set port environment variable
 ENV Port=25565

--- a/start.sh
+++ b/start.sh
@@ -64,6 +64,9 @@ if [ -e '/sbin/route' ]; then
 else
     DefaultRoute=$(route -n | awk '$4 == "UG" {print $2}')
 fi
+if [ -n "$DefaultRoute" ]; then
+      echo "     Network interface is up."
+fi
 NetworkChecks=0
 while [ -z "$DefaultRoute" ]; do
     echo "     Network interface not up, will try again in 1 second ..."

--- a/start.sh
+++ b/start.sh
@@ -21,16 +21,23 @@ if [ "$(id -u)" = '0' ]; then
     exec su minecraft -c "$0" "$@"
 fi
 
+echo "################################################################################################################"
 echo "Paper Minecraft Java Server Docker + Geyser/Floodgate script by James A. Chambers"
+echo "################################################################################################################"
 echo "Latest version always at https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate"
 echo "Don't forget to set up port forwarding on your router!  The default port is 25565 and the Bedrock port is 19132."
 
+echo ""
+echo "************************************************************************"
+echo "Prepare Environment"
+echo "************************************************************************"
+echo "Checking volume mount ..."
 if ! df -h | grep -q /minecraft; then
     echo "ERROR:  A named volume was not specified for the minecraft server data.  Please create one with: docker volume create yourvolumename"
     echo "Please pass the new volume to docker like this:  docker run -it -v yourvolumename:/minecraft"
     exit 1
 else
-    echo "Volume mount found for /minecraft"
+    echo "     Volume mount found for /minecraft"
 fi
 
 # Change directory to server directory
@@ -148,7 +155,7 @@ if [ ! -e "/minecraft/plugins/Geyser-Spigot/config.yml" ]; then
 fi
 
 # Update paperclip.jar
-echo "Updating to most recent paperclip version ..."
+echo "Updating to most recent Paper server version ..."
 
 # Test update website connectivity first
 if ! curl "${CurlArgs[@]}" \
@@ -167,7 +174,7 @@ else
 
     # Download latest build for the targeted version
     if [[ $Build != 0 ]]; then
-        echo "     Found latest paperclip build $Build for version $Version"
+        echo "     Found latest Paper build $Build for version $Version"
         curl ${QuietCurl:+"--no-progress-meter"} \
              "${CurlArgs[@]}" \
              -o /minecraft/paperclip.jar \
@@ -190,9 +197,10 @@ else
          -o /minecraft/plugins/Geyser-Spigot.jar \
          "https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/spigot"
 
+    echo "Updating ViaVersion ..."
     if [ -z "$NoViaVersion" ]; then
         # Update ViaVersion if new version is available
-        echo "Checking the latest version of ViaVersion ..."
+        echo "     Checking the latest version of ViaVersion ..."
         ViaVersionLatestVersion=$(curl --no-progress-meter \
             "${CurlArgs[@]}" \
             -k \
@@ -211,7 +219,7 @@ else
                 if [ -e /minecraft/plugins/ViaVersion.jar ] && [ "$ViaVersionLocalMD5" = "$ViaVersionLatestMD5" ]; then
                     echo "     ViaVersion is up to date: $ViaVersionLatestVersion"
                 else
-                    echo "     Updating ViaVersion ..."
+                    echo "     Downloading new version: $ViaVersionLatestVersion"
                     curl ${QuietCurl:+"--no-progress-meter"} \
                          "${CurlArgs[@]}" \
                          -k \
@@ -219,11 +227,11 @@ else
                          "https://ci.viaversion.com/job/ViaVersion/lastBuild/artifact/build/libs/$ViaVersionLatestVersion"
                 fi
             else
-                echo "Unable to check for updates to ViaVersion!"
+                echo "ERROR:  Unable to check for updates to ViaVersion!"
             fi
         fi
     else
-        echo "ViaVersion is disabled -- skipping"
+        echo "     ViaVersion is disabled -- skipping"
     fi
 fi
 
@@ -251,8 +259,9 @@ fi
 # Start server
 echo ""
 echo "************************************************************************"
-echo "Starting Minecraft server ..."
+echo "Launch Minecraft"
 echo "************************************************************************"
+echo "Starting Minecraft server ..."
 if [[ -z "$MaxMemory" ]] || [[ "$MaxMemory" -le 0 ]]; then
     exec java -XX:+UnlockDiagnosticVMOptions -XX:-UseAESCTRIntrinsics -DPaper.IgnoreJavaVersion=true -Xms400M -jar /minecraft/paperclip.jar
 else


### PR DESCRIPTION
This project is a great public resource, and I wanted to give back by putting some effort into giving things a facelift.

I have tested this new image repeatedly against a couple of my test instances in kubernetes that use this project.  The changes have worked well for me, there is a caveat here.  The image has been running as `root` for a long time, and recently `start.sh` was updated to have execution switch over to a new `minecraft` user after changing ownership of all files to the new user.

> [!WARNING]
> The changes here are not breaking (as far as I can tell) if people have already been running that most recent image with the `root` -> `minecraft` user.  *However*, if users have not previously launched with this more recent image, then all their files will still be owned by `root`, and images build from this PR will not be able to change ownership (since it runs as a non-root user, it cannot change ownership of files owned by `root`).
>
> **There is a workaround for this: run the container once as `root`.**  That will trigger the current (and retained) conditional block at the beginning of the script to change ownership of all files and then rerun the start script as the `minecraft` user.  Alternatively, users could go in and manually set ownership of everything in the `/minecraft` directory to the `minecraft` user/group (uid:gid 999:999).
>
> This is easily done in a compose file by adding `user: root` to the minecraft container service.  For example:
> ```yaml
> ...
> services:
>   minecraftbe:
>     image: 05jchambers/legendary-minecraft-geyser-floodgate:latest
>     user: root
> ...
> ```
> Run it that way once, then afterwards you can remove that additional line.
> 
> In kubernetes, the same thing can be accomplished by defining the `spec.template.spec.securityContext` for the Deployment/StatefulSet.  For example:
> ```yaml
> ...
> spec:
> ...
>   template:
>   ...
>     spec:
>       securityContext:
>         runAsUser: 0
>         runAsGroup: 0
> ...
> ```

> [!IMPORTANT]
> This branch is based on the other PR I submitted (#42) to update `start.sh` to work with the new endpoint for PaperMC's API.  That one should be merged before this one.

There are a lot of changes here, but I'll do my best to summarize/explain them here:
* Dockerfiles
  * amd64
    * Removed the unneeded builder stage since nothing from it is copied over to the main stage
  * non-amd64
    * Added the platform to the builder stage.  Note that this way of doing multiarch images (hardcoding the platform inside the Dockerfile) is discouraged by Docker now, and generates warnings when building the images.
  * All
    * Removed the `sudo` package, since it isn't needed anymore
    * Alphabetized the package installs and broke up the main one to one package per line for better visibility and easier auditing
    * Changed the `apt update` to the preferred `apt-get update` for scripting
    * Create the `minecraft` user and group
    * Create the `/minecraft` directory (so that we can set it as the WORKDIR) and set its permissions
    * Set the default USER to `minecraft`
    * Set the WORKDIR to `/minecraft` so when we exec into the container, it drops us right into that directory
* `start.sh`
  *  Made a lot of tweaks to the logging/echos in the script to make the log output more informative, clear, and easier to parse.
  * Changed the logic for respecting the `QuietCurl` override so that each command using it is not duplicated.  Duplication like that is an easy way to introduce bugs by forgetting to make a change to both commands.  Replicated this same approach to similar command duplication in the script as well.
  * Made changes to resolve with a handful of bash linting (ShellCheck) warnings (unused variables, `find` vs `ls -1tr`, double quotes on variables to prevent globbing, `||` conditions when changing directories, checking for variable/env var existence before use, etc.)
  * Broke up long commands with lots of flags into multi-line commands for readability and auditability.
  * Changed the backup tar command to not be verbose.  It makes the logs SO long when dumping them from Docker or Kubernetes and I didn't see the value in listing every single file that is put into the backup.  I messed around a while with tar checkpoints, but some of our backups are going to be pretty big with large enough maps, so in the end I opted to just omit all of that.
  * Reworked the command to delete old backups primarily based on ShellCheck suggestions.  I did test the new logic and it consistently worked.  Note that setting `BackupCount` to 0 will delete all backups.
  * Consolidated the Paper build `jq` logic to automatically fall back to check the latest experimental channel build if no default channel builds are found for the desired version.  This was done to, again, remove the need for a duplicated command that could lead to bugs over time.
  * Abstracted away the common `curl` arguments/flags into an array so they didn't clutter up the script as much.
  * Moved the port variable checks down to where the port values are set in the config files.

I think that about covers it.  I am happy to discuss anything that seems confusing or why I made some of the choices I did.

Fixes #41, which is what lead me down this path anyway, since you can't actually run the container as the `minecraft` user in its current state, which, in my opinion, is the "better" way to do this vs obfuscating it within the entrypoint script.