### PR TITLE
Update start.sh to work with Paper's new v3 API.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -154,15 +154,15 @@ if [ "$?" != 0 ]; then
     echo "Unable to connect to update website (internet connection may be down).  Skipping update ..."
 else
     # Get latest build
-    BuildJSON=$(curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" https://api.papermc.io/v2/projects/paper/versions/$Version)
+    BuildJSON=$(curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Legendary Minecraft Docker Script (https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate)" https://fill.papermc.io/v3/projects/paper/versions/$Version)
     Build=$(echo "$BuildJSON" | rev | cut -d, -f 1 | cut -d']' -f 2 | cut -d'[' -f 1 | rev)
     Build=$(($Build + 0))
     if [[ $Build != 0 ]]; then
         echo "Latest paperclip build found: $Build"
         if [ -z "$QuietCurl" ]; then
-            curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" -o /minecraft/paperclip.jar "https://api.papermc.io/v2/projects/paper/versions/$Version/builds/$Build/downloads/paper-$Version-$Build.jar"
+            curl -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Legendary Minecraft Docker Script (https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate)" -o /minecraft/paperclip.jar "https://fill.papermc.io/v3/projects/paper/versions/$Version/builds/$Build/downloads/paper-$Version-$Build.jar"
         else
-            curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" -o /minecraft/paperclip.jar "https://api.papermc.io/v2/projects/paper/versions/$Version/builds/$Build/downloads/paper-$Version-$Build.jar"
+            curl --no-progress-meter -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Legendary Minecraft Docker Script (https://github.com/TheRemote/Legendary-Java-Minecraft-Geyser-Floodgate)" -o /minecraft/paperclip.jar "https://fill.papermc.io/v3/projects/paper/versions/$Version/builds/$Build/downloads/paper-$Version-$Build.jar"
         fi
     else
         echo "Unable to retrieve latest Paper build (got result of $Build)"


### PR DESCRIPTION
Paper changed their API and sunset their v2 API on Dec.31, 2025.  I have attempted to update the script to use the new v3 API and user agent requirements, but I don't really know what I'm doing... probably broke something.

Details of the API changes: https://discord.com/channels/289587909051416579/492517675680006144/1387884496212201742

📦 Fill v3 — New Version of the Download Service
We've launched a new version of Fill, formerly known as Bibliothek — the download service powering our website, server panels, and various download scripts.

👥 Who Is Affected?
These changes primarily affect:
Server hosts
Tooling developers (e.g. launchers, pack installers, CI scripts)

If you're downloading from our website, you are not affected - and if you're using a server host, they will handle the migration for you.

🎁 What's New
🌏 New API Domain

The primary API domain has changed:
api.papermc.io ➜ fill.papermc.io

The old domain (api.papermc.io) will remain available for Fill v2 until it is sunset.
Fill v3 and the new GraphQL endpoint are only available via fill.papermc.io

Make sure to update your tooling and scripts accordingly.

🏷️ As seen with the release of Paper 1.21.6, we’ve started tracking select non-release versions of Minecraft. To support this, we’ve overhauled the build channel system:
ALPHA — Early, unstable builds
BETA — Feature-complete, may have bugs
STABLE — Production-ready builds
RECOMMENDED — Latest stable version recommended for general use
 ⚠️ Heads up: Some projects may not use all the available channels. The RECOMMENDED channel replaces the promoted status from v2, and is currently only used by Velocity. 

📁 Download URLs are now embedded directly in API responses and point to our new domain: fill-data.papermc.io.
You no longer need to manually construct URLs — and we advise against doing so, as the format may change.

📜 We’ve also added new version-level metadata, especially useful for server hosts:
Support status (SUPPORTED, DEPRECATED, UNSUPPORTED)
Support end date (ISO-8601 format: YYYY-MM-DD)
Minimum required Java version
Recommended JVM flags

📘 API Documentation (Swagger)
You can explore the full Fill v3 REST API using our Swagger UI:
🔗 https://fill.papermc.io/swagger-ui/index.html

🔎 GraphQL Support
Fill now includes an optional GraphQL endpoint for advanced queries. Try it out here: https://fill.papermc.io/graphiql
⚠️ Heads up: GraphQL support is experimental and subject to change at any time.

🔨 Breaking Changes
🔁  Download key changes
Some download keys have changed in Fill v3 and GraphQL responses:
application -> server:default
mojang-mappings -> server:mojang

🔐 Required User-Agent Header
All requests must now include a valid User-Agent header that:
Clearly identifies your software or company
Is not generic (e.g. curl, wget, or similar defaults)
Includes a contact URL or email address (e.g. a homepage, bot info page, or support email)

Examples of valid headers:

mc-image-helper/1.39.11 (https://github.com/itzg/docker-minecraft-server)
nodecraft/packifier/1.0.0 (staff@nodecraft.com)

Requests without a valid User-Agent may be rejected or rate-limited.

🌅 Fill v2 Sunsetting Timeline
December 31, 2025: the v2 API will stop receiving new builds at the end of this year, 23 days ago
July 1, 2026: the v2 API will be disabled and no longer accessible in 5 months